### PR TITLE
plamo: Update the default version to 7.x

### DIFF
--- a/templates/lxc-plamo.in
+++ b/templates/lxc-plamo.in
@@ -374,7 +374,7 @@ usage() {
 prog=`basename $0`
 path="" ; name="" ; rootfs=""
 clean=0
-release=${release:-6.x}
+release=${release:-7.x}
 arch=`uname -m | sed 's/i.86/x86/'` ; hostarch=$arch
 bindhome=""
 sopts=hp:n:cr:a:b:


### PR DESCRIPTION
Now, 7.x is our stable version.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>