### PR TITLE
Add new dependency for wget for lxc-slackware template

### DIFF
--- a/templates/lxc-slackware.in
+++ b/templates/lxc-slackware.in
@@ -566,6 +566,7 @@ grep
 gzip
 hostname
 iputils
+libpsl
 libunistring
 logrotate
 mpfr
@@ -574,6 +575,7 @@ network-scripts
 ncurses
 openssh
 openssl-solibs
+pcre2
 pkgtools
 procps-ng
 sed


### PR DESCRIPTION
Two more packages: libpsl and pcre2.
These libraries are needed by wget command, which is used in the built-in package manager, slackpkg.
Signed-off-by: CCHsu <a12321aabb@gmail.com>