### PR TITLE
plamo: Workaround for building plamo 32bit 6.x container on current 7.x

### DIFF
--- a/templates/lxc-plamo.in
+++ b/templates/lxc-plamo.in
@@ -123,6 +123,7 @@ install_plamo() {
        pkgtool="pkgtools"
     else
        pkgtool="hdsetup"
+       LANG=C
     fi
 
     ( cd $dlcache ; tar xpJf "$pkgtool"-*.txz ; rm -rf tmp usr var )


### PR DESCRIPTION
Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>