### PR TITLE
plamo: remove unnecesssary initpkg execution at container config

### DIFF
--- a/templates/lxc-plamo.in
+++ b/templates/lxc-plamo.in
@@ -281,18 +281,12 @@ configure_plamo7() {
 	SERVICE="dhclient"
 	EOF
 
-    # initpkg
+    # remove initpkg that does not exec
     noexec="shadow netconfig7 eudev openssh"
     for f in $noexec
     do
       rm -f $rootfs/var/log/initpkg/"$f"
     done
-    pushd $rootfs
-    for f in var/log/initpkg/*
-    do
-      chroot $rootfs sh ./$f
-    done
-    popd
 }
 
 configure_plamo() {


### PR DESCRIPTION
We do not have to re-execute initpkg at container configuration.
The remaining initpkg script will be executed at container startup.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>