### PR TITLE
lxc-debian: fix incorrect use of basename instead of dirname

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -385,7 +385,7 @@ openssh-server
             echo "Failed to download the rootfs, aborting."
             return 1
         fi
-        mkdir -p "$(basename "$cache/partial-$release-$arch/$interpreter_path")"
+        mkdir -p "$(dirname "$cache/partial-$release-$arch/$interpreter_path")"
         cp "$interpreter" "$cache/partial-$release-$arch/$interpreter_path"
         if [ $? -ne 0 ]; then
             echo "failed to copy $interpreter to $cache/partial-$release-$arch/$interpreter_path"


### PR DESCRIPTION
mkdir -p should create the dirname of the interpreter, not its basename.

Signed-off-by: Anders Oleson <anders-code@users.noreply.github.com>

fixes #26 