### PR TITLE
[lxc-debian] Handle languages that are only UTF-8 encoded

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -129,7 +129,8 @@ EOF
         chroot "$rootfs" locale-gen en_US.UTF-8 UTF-8
         chroot "$rootfs" update-locale LANG=en_US.UTF-8
     else
-        encoding=$(echo "$LANG" | cut -d. -f2)
+        encoding=$(locale charmap)
+        [ -z "${encoding}" ] && encoding="UTF-8"
         chroot "$rootfs" sed -e "s/^# \(${LANG} ${encoding}\)/\1/" \
             -i /etc/locale.gen 2> /dev/null
         cat >> "$rootfs/etc/locale.gen" << EOF


### PR DESCRIPTION
Fixes #28 