### PR TITLE
Improvements and bugfixes to templates/lxc-devuan.in and templates/lxc-kali.in

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -186,10 +186,12 @@ EOF
     # set initial timezone as on host
     if [ -f /etc/timezone ]; then
         cat /etc/timezone > "$rootfs/etc/timezone"
+        rm -f "$rootfs/etc/localtime"
         chroot "$rootfs" dpkg-reconfigure -f noninteractive tzdata
     elif [ -f /etc/sysconfig/clock ]; then
         . /etc/sysconfig/clock
         echo "$ZONE" > "$rootfs/etc/timezone"
+        rm -f "$rootfs/etc/localtime"
         chroot "$rootfs" dpkg-reconfigure -f noninteractive tzdata
     else
         echo "Timezone in container is not configured. Adjust it manually."

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -5,6 +5,8 @@
 
 # Authors:
 # Daniel Lezcano <daniel.lezcano@free.fr>
+# Greg Olsen     <gregolsen@computer.org>  (lxc-devuan)
+# Tanya          <tanyadegurechaff@waifu.club>
 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -594,6 +594,11 @@ EOF
 
     # Re-enable service startup
     rm "${rootfs}/usr/sbin/policy-rc.d"
+
+    # Fix by Greg Olsen, avoid warning 'stdin not a tty' in some cases
+    if [[ -f "${rootfs}/root/.profile" ]]; then
+       sed -i -e 's/^mesg n/test -t 0 \&\& mesg n/g' ${rootfs}/root/.profile
+    fi
     
     # end
 }

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -650,7 +650,7 @@ Environment variables:
   SECURITY_MIRROR        The Debian package security mirror to use. See also the --security-mirror switch above.
                          Defaults to '$SECURITY_MIRROR'
   DOWNLOAD_KEYRING       Sets whether to download keyring when missing or ignore keyring checks
-                         Defaults to '1'
+                         Defaults to 1
 
 EOF
     return 0

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -122,6 +122,17 @@ EOF
 $hostname
 EOF
 
+    # set minimal hosts
+    cat <<EOF > $rootfs/etc/hosts
+127.0.0.1   localhost
+127.0.1.1   $hostname
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+EOF
+
     # reconfigure some services
 
     # but first reconfigure locales - so we get no noisy perl-warnings

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -143,7 +143,8 @@ EOF
         chroot "$rootfs" locale-gen en_US.UTF-8 UTF-8
         chroot "$rootfs" update-locale LANG=en_US.UTF-8
     else
-        encoding=$(echo "$LANG" | cut -d. -f2)
+        encoding=$(locale charmap)
+        [ -z "${encoding}" ] && encoding="UTF-8"
         chroot "$rootfs" sed -e "s/^# \(${LANG} ${encoding}\)/\1/" \
             -i /etc/locale.gen 2> /dev/null
         cat >> "$rootfs/etc/locale.gen" << EOF

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -649,6 +649,8 @@ Environment variables:
                          Defaults to '$MIRROR'
   SECURITY_MIRROR        The Debian package security mirror to use. See also the --security-mirror switch above.
                          Defaults to '$SECURITY_MIRROR'
+  DOWNLOAD_KEYRING       Sets whether to download keyring when missing or ignore keyring checks
+                         Defaults to '1'
 
 EOF
     return 0

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -40,6 +40,7 @@ LOCALSTATEDIR="@LOCALSTATEDIR@"
 LXC_TEMPLATE_CONFIG="@LXCTEMPLATECONFIG@"
 # Allows the lxc-cache directory to be set by environment variable
 LXC_CACHE_PATH=${LXC_CACHE_PATH:-"$LOCALSTATEDIR/cache/lxc"}
+[ -z "$DOWNLOAD_KEYRING" ] && DOWNLOAD_KEYRING=1
 
 find_interpreter()
 {
@@ -347,18 +348,32 @@ openssh-server
 
     # If debian-archive-keyring isn't installed, fetch GPG keys directly
     releasekeyring=/usr/share/keyrings/debian-archive-keyring.gpg
-    if [ ! -f $releasekeyring ]; then
-        releasekeyring="$cache/archive-key.gpg"
-        case $release in
-            "wheezy")
-                gpgkeyname="archive-key-7.0"
-                ;;
-            *)
-                gpgkeyname="archive-key-8"
-                ;;
-        esac
-        wget https://ftp-master.debian.org/keys/${gpgkeyname}.asc -O - --quiet \
-            | gpg --import --no-default-keyring --keyring="${releasekeyring}"
+    lreleasekeyring=/etc/apt/trusted.gpg.d/debian-archive-$release-stable.gpg
+    if [ -f "$releasekeyring" ]; then
+        apt_gpg_opt="--keyring=${releasekeyring}"
+    elif [ -f "$lreleasekeyring" ]; then
+        apt_gpg_opt="--keyring=${lreleasekeyring}"
+    elif [ "$DOWNLOAD_KEYRING" = 1 ]; then 
+        [ ! -d "/etc/apt/trusted.gpg.d" ] && lreleasekeyring="$cache/archive-key.gpg"
+        if [[ "$(id -u)" == "0" ]]; then
+            case $release in
+                "wheezy")
+                    gpgkeyname="archive-key-7.0"
+                    ;;
+                *)
+                    gpgkeyname="archive-key-8"
+                    ;;
+            esac
+            wget https://ftp-master.debian.org/keys/${gpgkeyname}.asc -O - --quiet \
+                | gpg --import --no-default-keyring --keyring="${lreleasekeyring}"
+            apt_gpg_opt="--keyring=${lreleasekeyring}"
+        else
+           echo "Must be root (sudo) to save $lreleasekeyring"
+        fi
+    fi
+    if [ -z "$apt_gpg_opt" ]; then
+        echo "WARNING: No GPG check"
+        apt_gpg_opt='--no-check-gpg'
     fi
     # check the mini debian was not already downloaded
     try_mksubvolume "$cache/partial-$release-$arch"
@@ -371,7 +386,7 @@ openssh-server
     echo "Downloading debian minimal ..."
     if [ "$interpreter" = "" ] ; then
         debootstrap --verbose --variant=minbase --arch="$arch" \
-            --include=$packages --keyring="${releasekeyring}" \
+            --include=$packages "${apt_gpg_opt}" \
             "$release" "$cache/partial-$release-$arch" "$MIRROR"
         if [ $? -ne 0 ]; then
             echo "Failed to download the rootfs, aborting."
@@ -379,7 +394,7 @@ openssh-server
         fi
     else
         debootstrap --foreign --verbose --variant=minbase --arch="$arch" \
-            --include=$packages --keyring="${releasekeyring}" \
+            --include=$packages "${apt_gpg_opt}" \
             "$release" "$cache/partial-$release-$arch" "$MIRROR"
         if [ $? -ne 0 ]; then
             echo "Failed to download the rootfs, aborting."

--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -226,7 +226,7 @@ write_sourceslist()
     fi
 
     cat >> "${rootfs}/etc/apt/sources.list" << EOF
-${prefix} $MIRROR          ${release}         main${non_main}
+${prefix} $MIRROR ${release} main${non_main}
 EOF
 
     if [ "$release" != "unstable" -a "$release" != "sid" ]; then

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -123,6 +123,17 @@ EOF
 $hostname
 EOF
 
+    # set minimal hosts
+    cat <<EOF > $rootfs/etc/hosts
+127.0.0.1   localhost
+127.0.1.1   $hostname
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+EOF
+
     # reconfigure some services
 
     # but first reconfigure locales - so we get no noisy perl-warnings

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -621,6 +621,8 @@ Environment variables:
 
   MIRROR                 The Kali package mirror to use. See also the --mirror switch above.
                          Defaults to '$MIRROR'
+  DOWNLOAD_KEYRING       Sets whether to download keyring when missing or ignore keyring checks
+                         Defaults to '1'
 EOF
     return 0
 }

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -144,7 +144,8 @@ EOF
         chroot "$rootfs" locale-gen en_US.UTF-8 UTF-8
         chroot "$rootfs" update-locale LANG=en_US.UTF-8
     else
-        encoding=$(echo "$LANG" | cut -d. -f2)
+        encoding=$(locale charmap)
+        [ -z "${encoding}" ] && encoding="UTF-8"
         chroot "$rootfs" sed -e "s/^# \(${LANG} ${encoding}\)/\1/" \
             -i /etc/locale.gen 2> /dev/null
         cat >> "$rootfs/etc/locale.gen" << EOF

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -5,7 +5,9 @@
 
 # Authors:
 # Daniel Lezcano <daniel.lezcano@free.fr>
-# Re4son <re4son@kali.org>
+# Re4son         <re4son@kali.org>
+# Greg Olsen     <gregolsen@computer.org>  (lxc-devuan)
+# Tanya          <tanyadegurechaff@waifu.club>
 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -622,7 +622,7 @@ Environment variables:
   MIRROR                 The Kali package mirror to use. See also the --mirror switch above.
                          Defaults to '$MIRROR'
   DOWNLOAD_KEYRING       Sets whether to download keyring when missing or ignore keyring checks
-                         Defaults to '1'
+                         Defaults to 1
 EOF
     return 0
 }

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -181,10 +181,12 @@ EOF
     # set initial timezone as on host
     if [ -f /etc/timezone ]; then
         cat /etc/timezone > "$rootfs/etc/timezone"
+        rm -f "$rootfs/etc/localtime"
         chroot "$rootfs" dpkg-reconfigure -f noninteractive tzdata
     elif [ -f /etc/sysconfig/clock ]; then
         . /etc/sysconfig/clock
         echo "$ZONE" > "$rootfs/etc/timezone"
+        rm -f "$rootfs/etc/localtime"
         chroot "$rootfs" dpkg-reconfigure -f noninteractive tzdata
     else
         echo "Timezone in container is not configured. Adjust it manually."

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -221,7 +221,7 @@ write_sourceslist()
     fi
 
     cat >> "${rootfs}/etc/apt/sources.list" << EOF
-${prefix} $MIRROR          ${release}         main${non_main}
+${prefix} $MIRROR ${release} main${non_main}
 EOF
 
 }

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -570,6 +570,11 @@ EOF
 
     # Re-enable service startup
     rm "${rootfs}/usr/sbin/policy-rc.d"
+
+    # Fix by Greg Olsen, avoid warning 'stdin not a tty' in some cases
+    if [[ -f "${rootfs}/root/.profile" ]]; then
+       sed -i -e 's/^mesg n/test -t 0 \&\& mesg n/g' ${rootfs}/root/.profile
+    fi
     
     # end
 }

--- a/templates/lxc-kali.in
+++ b/templates/lxc-kali.in
@@ -41,6 +41,7 @@ LOCALSTATEDIR="@LOCALSTATEDIR@"
 LXC_TEMPLATE_CONFIG="@LXCTEMPLATECONFIG@"
 # Allows the lxc-cache directory to be set by environment variable
 LXC_CACHE_PATH=${LXC_CACHE_PATH:-"$LOCALSTATEDIR/cache/lxc"}
+[ -z "$DOWNLOAD_KEYRING" ] && DOWNLOAD_KEYRING=1
 
 find_interpreter()
 {
@@ -330,11 +331,25 @@ kali-archive-keyring
 
     # If kali-archive-keyring isn't installed, fetch GPG keys directly
     releasekeyring=/usr/share/keyrings/kali-archive-keyring.gpg
-    if [ ! -f $releasekeyring ]; then
-        releasekeyring="$cache/archive-key.gpg"
-        gpgkeyname="archive-key"
-        wget https://archive.kali.org/${gpgkeyname}.asc -O - --quiet \
-            | gpg --import --no-default-keyring --keyring="${releasekeyring}"
+    lreleasekeyring=/etc/apt/trusted.gpg.d/kali-archive-keyring.gpg
+    if [ -f "$releasekeyring" ]; then
+        apt_gpg_opt="--keyring=${releasekeyring}"
+    elif [ -f "$lreleasekeyring" ]; then
+        apt_gpg_opt="--keyring=${lreleasekeyring}"
+    elif [ "$DOWNLOAD_KEYRING" = 1 ]; then 
+        [ ! -d "/etc/apt/trusted.gpg.d" ] && lreleasekeyring="$cache/archive-key.gpg"
+        if [[ "$(id -u)" == "0" ]]; then
+            gpgkeyname="archive-key"
+            wget https://archive.kali.org/${gpgkeyname}.asc -O - --quiet \
+                | gpg --import --no-default-keyring --keyring="${lreleasekeyring}"
+            apt_gpg_opt="--keyring=${lreleasekeyring}"
+        else
+           echo "Must be root (sudo) to save $lreleasekeyring"
+        fi
+    fi
+    if [ -z "$apt_gpg_opt" ]; then
+        echo "WARNING: No GPG check"
+        apt_gpg_opt='--no-check-gpg'
     fi
     # check the mini kali was not already downloaded
     try_mksubvolume "$cache/partial-$release-$arch"
@@ -347,7 +362,7 @@ kali-archive-keyring
     echo "Downloading kali minimal ..."
     if [ "$interpreter" = "" ] ; then
         debootstrap --verbose --variant=minbase --arch="$arch" \
-            --include=$packages --keyring="${releasekeyring}" \
+            --include=$packages "${apt_gpg_opt}" \
             "$release" "$cache/partial-$release-$arch" "$MIRROR"
         if [ $? -ne 0 ]; then
             echo "Failed to download the rootfs, aborting."
@@ -355,7 +370,7 @@ kali-archive-keyring
         fi
     else
         debootstrap --foreign --verbose --variant=minbase --arch="$arch" \
-            --include=$packages --keyring="${releasekeyring}" \
+            --include=$packages "${apt_gpg_opt}" \
             "$release" "$cache/partial-$release-$arch" "$MIRROR"
         if [ $? -ne 0 ]; then
             echo "Failed to download the rootfs, aborting."


### PR DESCRIPTION
replaces: #29
Various improvements and bugfixes for debian and kali templates figured out or taken from the work of Greg Olsen.
Little note, in last merge with a kali template repo you didn't add lxc-kali in templates/Makefile.am and kali common/userns configs to config/Makefile.am. You also didn't change permissions of templates/lxc-kali.in from 755 to 644

I don't know if it's intentional or not, in doubt I didn't change anything and just advised