### PR TITLE
plamo: Support current pkgtools

### DIFF
--- a/templates/lxc-plamo.in
+++ b/templates/lxc-plamo.in
@@ -123,13 +123,18 @@ install_plamo() {
     echo "Installing 'installpkg' command into $dlcache/sbin..."
 
     if [ $majorver -ge 7 ]; then
-       pkgtool="pkgtools"
+      pkgtool="pkgtools"
+      pkgtool=$( cd $dlcache ; ls "$pkgtool"* )
+      pkgtool=${pkgtool%%-*}
     else
-       pkgtool="hdsetup"
-       LANG=C
+      pkgtool="hdsetup"
+      LANG=C
     fi
 
     ( cd $dlcache ; tar xpJf "$pkgtool"-*.txz ; rm -rf tmp usr var )
+    if [ $pkgtool = "pkgtools${majorver}" ]; then
+	( cd $dlcache/sbin ; mv installer_new installer )
+    fi
 
     sed -i "/ldconfig/!s@/sbin@$dlcache&@g" $dlcache/sbin/installpkg*
     PATH=$dlcache/sbin:$PATH


### PR DESCRIPTION
Our package manager "pkgtools" is updated, and renamed "pkgtools7".

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>