### PR TITLE
Changed security distribution to ${release}-security.

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -242,7 +242,7 @@ EOF
 
     if [ "$release" != "unstable" -a "$release" != "sid" ]; then
       cat >> "${rootfs}/etc/apt/sources.list" << EOF
-${prefix} $SECURITY_MIRROR ${release}/updates main${non_main}
+${prefix} $SECURITY_MIRROR ${release}-security main${non_main}
 EOF
     fi
 }


### PR DESCRIPTION
Addressing issue #39 where the Debian security distribution field is incorrect for the lxc-debian template.

Signed-off-by: Matthew Bruzek <mbruzek@gmail.com>