### PR TITLE
Fix alpine lxc build

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -40,15 +40,24 @@ readonly LXC_CACHE_DIR="${LXC_CACHE_PATH:-"$LOCAL_STATE_DIR/cache/lxc"}/alpine"
 # SHA256 checksums of GPG keys for APK.
 readonly APK_KEYS_SHA256="\
 9c102bcc376af1498d549b77bdbfa815ae86faa1d2d82f040e616b18ef2df2d4  alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
-2adcf7ce224f476330b5360ca5edb92fd0bf91c92d83292ed028d7c4e26333ab  alpine-devel@lists.alpinelinux.org-4d07755e.rsa.pub
 ebf31683b56410ecc4c00acd9f6e2839e237a3b62b5ae7ef686705c7ba0396a9  alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
 1bb2a846c0ea4ca9d0e7862f970863857fc33c32f5506098c636a62a726a847b  alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
 12f899e55a7691225603d6fb3324940fc51cd7f133e7ead788663c2b7eecb00c  alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
 73867d92083f2f8ab899a26ccda7ef63dfaa0032a938620eda605558958a8041  alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub
 9a4cd858d9710963848e6d5f555325dc199d1c952b01cf6e64da2c15deedbd97  alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
-780b3ed41786772cbc7b68136546fa3f897f28a23b30c72dde6225319c44cfff  alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub"
+780b3ed41786772cbc7b68136546fa3f897f28a23b30c72dde6225319c44cfff  alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub
+59c01c57b446633249f67c04b115dd6787f4378f183dff2bbf65406df93f176d  alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub
+db0b49163f07ffba64a5ca198bcf1688610b0bd1f0d8d5afeaf78559d73f2278  alpine-devel@lists.alpinelinux.org-60ac2099.rsa.pub
+207e4696d3c05f7cb05966aee557307151f1f00217af4143c1bcaf33b8df733f  alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
+128d34d4aec39b0daedea8163cd8dc24dff36fd3d848630ab97eeb1d3084bbb3  alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
+10877cce0a935e46ad88cb79e174a2491680508eccda08e92bf04fb9bf37fbc1  alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub
+4a095a9daca86da496a3cd9adcd95ee2197fdbeb84638656d469f05a4d740751  alpine-devel@lists.alpinelinux.org-616abc23.rsa.pub
+0caf5662fde45616d88cfd7021b7bda269a2fcaf311e51c48945a967a609ec0b  alpine-devel@lists.alpinelinux.org-616ac3bc.rsa.pub
+ebe717d228555aa58133c202314a451f81e71f174781fd7ff8d8970d6cfa60da  alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub
+d11f6b21c61b4274e182eb888883a8ba8acdbf820dcc7a6d82a7d9fc2fd2836d  alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub
+40a216cbd163f22e5f16a9e0929de7cde221b9cbae8e36aa368b1e128afe0a31  alpine-devel@lists.alpinelinux.org-616db30d.rsa.pub"
 
-readonly APK_KEYS_URI='http://alpinelinux.org/keys'
+readonly APK_KEYS_URI='https://git.alpinelinux.org/aports/plain/main/alpine-keys/'
 readonly DEFAULT_MIRROR_URL='http://dl-cdn.alpinelinux.org/alpine'
 
 : ${APK_KEYS_DIR:=/etc/apk/keys}
@@ -277,11 +286,6 @@ install_packages() {
 make_dev_nodes() {
 	mkdir -p -m 755 dev/pts
 	mkdir -p -m 1777 dev/shm
-
-	mknod -m 666 dev/zero c 1 5
-	mknod -m 666 dev/full c 1 7
-	mknod -m 666 dev/random c 1 8
-	mknod -m 666 dev/urandom c 1 9
 
 	local i; for i in $(seq 0 4); do
 		mknod -m 620 dev/tty$i c 4 $i


### PR DESCRIPTION
This fixes a couple issues that prevents building alpine containers. First, we set a better list of apk keys to use for verification of bootstrap packages. Then we removed extra `mknod` calls to create character devices, and let lxc config handle this at container start (fixes #43).