### PR TITLE
templates/lxc-gentoo.in: Propperly handle aarch64.

### DIFF
--- a/templates/lxc-gentoo.in
+++ b/templates/lxc-gentoo.in
@@ -89,6 +89,9 @@ set_default_arch()
     elif [[ $arch =~ arm.* ]]; then
         arch="arm"
         variant="armv7a"
+    elif [[ $arch == "aarch64" ]]; then
+        arch="arm64"
+        variant="arm64-openrc"
     else
         #who knows, it may work...
         printf " => warn: unexpected arch:${arch} let me knows if it works :)\n"


### PR DESCRIPTION
Gentoo uses arm64 in the download path. See

  http://distfiles.gentoo.org/releases/arm64/autobuilds/