### PR TITLE
lxc-debian: fix getopt parsing of --mirror

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -715,7 +715,7 @@ EOF
     return 0
 }
 
-options=$(getopt -o hp:n:a:r:cI:FS: -l arch:,auth-key:,clean,help,enable-non-free,mirror:keyring:,name:,packages:,path:,release:,rootfs:,security-mirror:,interpreter-path:,flush-cache -- "$@")
+options=$(getopt -o hp:n:a:r:cI:FS: -l arch:,auth-key:,clean,help,enable-non-free,keyring:,mirror:,name:,packages:,path:,release:,rootfs:,security-mirror:,interpreter-path:,flush-cache -- "$@")
 if [ $? -ne 0 ]; then
         usage "$(basename "$0")"
         exit 1


### PR DESCRIPTION
When the `--keyring` option was added in eebcd76feb47, the `,` between `mirror:` and `keyring:` was omitted in the long option string passed to `getopt`. This causes `--mirror` to be parsed as `--mirror:keyring`, matching `*) break ;;` and prematurely terminating option parsing.  To avoid this, add the missing `,`.  Also order `keyring:` before `mirror:` to preserve lexical ordering of long options.

Thanks for considering,
Kevin