### PR TITLE
lxc-debian: improve detection of official architectures

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -786,18 +786,22 @@ if [ "$arch" = "x86_64" ]; then
 fi
 
 
-testing_release_file=${DEBIAN_MIRROR}/dists/testing/main/binary-${arch}/Release
-if ! wget -q -O /dev/null "${testing_release_file}"; then
-  echo "${arch} does not look like a release architecture, trying debian ports"
-  # non-release architecture; assume debian-ports architecture
-  if [ "${MIRROR}" = "${DEBIAN_MIRROR}" ]; then
-    MIRROR="${DEBIAN_PORTS_MIRROR}"
+release_file=${DEBIAN_MIRROR}/dists/${release}/main/binary-${arch}/Release
+if ! wget -q -O /dev/null "${release_file}"; then
+  if [ "${release}" = unstable ] || [ "${release}" = sid ]; then
+    echo "${arch}/${release} not available on mirror, trying debian ports"
+    # non-release architecture; assume debian-ports architecture
+    if [ "${MIRROR}" = "${DEBIAN_MIRROR}" ]; then
+      MIRROR="${DEBIAN_PORTS_MIRROR}"
+    fi
+    if [ "${KEYRING}" = "${DEBIAN_ARCHIVE_KEYRING}" ]; then
+      KEYRING="${DEBIAN_PORTS_ARCHIVE_KEYRING}"
+    fi
+    packages="debian-ports-archive-keyring,${packages}"
+  else
+    echo "Error: ${arch}/${release} not available on mirror ${DEBIAN_MIRROR}"
+    exit 1
   fi
-  if [ "${KEYRING}" = "${DEBIAN_ARCHIVE_KEYRING}" ]; then
-    KEYRING="${DEBIAN_PORTS_ARCHIVE_KEYRING}"
-  fi
-  packages="debian-ports-archive-keyring,${packages}"
-  release="${release:-unstable}"
 fi
 
 if [ "$interpreter" = "" ] ; then


### PR DESCRIPTION
An official architecture is not always available in testing. New architectures get added to unstable first, and only some time after that they *may* get added to testing as well. This is just now happening with riscv64, and checking whether it's available in testing will *not* give the correct answer for the question "is this an official Debian architecture?".

Also, since debian-ports only contain unstable, just refuse to use debian-ports if not creating an unstable/sid container.