### PR TITLE
lxc-debian: support installation of dialog-like program

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -367,12 +367,19 @@ download_debian()
         iproute=iproute2
         ;;
     esac
+    if [ `apt search dialog |grep ^dialog\/ |wc -l` != 0 ]; then
+        dialoglike="dialog"
+    elif [ `apt search whiptail |grep ^whiptail\/ |wc -l` != 0 ]; then
+        dialoglike="whiptail"
+    elif [ `apt search Xdialog |grep ^Xdialog\/ |wc -l` != 0 ]; then
+        dialoglike="Xdialog"
+    fi
     packages=\
 $init,\
 ifupdown,\
 locales,\
 ca-certificates,\
-dialog,\
+$dialoglike,\
 isc-dhcp-client,\
 netbase,\
 net-tools,\


### PR DESCRIPTION
When the dialog is not installed on the system, an error will be reported: "No usable dialog-like program is installed, so the dialog based frontend cannot be used".
According to the file /usr/share/perl5/Debconf/FrontEnd/Dialog.pm, in addition to installing dialog, whiptail and Xdialog can also be used instead, especially when the system used does not support dialog.
The relevant code in /usr/share/perl5/Debconf/FrontEnd/Dialog.pm is as follows：
```
        if (Debconf::Path::find("whiptail") &&  
            (! defined $ENV{DEBCONF_FORCE_DIALOG} || ! Debconf::Path::find("dialog")) &&
            (! defined $ENV{DEBCONF_FORCE_XDIALOG} || ! Debconf::Path::find("Xdialog")) &&
            system('whiptail --version >/dev/null 2>&1') == 0) {
                $this->program('whiptail');
                $this->dashsep('--');
                $this->borderwidth(5);
                $this->borderheight(6);
                $this->spacer(1);
                $this->titlespacer(10);
                $this->columnspacer(3);
                $this->selectspacer(13);
                $this->hasoutputfd(1);
        }   
        elsif (Debconf::Path::find("dialog") &&
               (! defined $ENV{DEBCONF_FORCE_XDIALOG} || ! Debconf::Path::find("Xdialog")) &&
               system('dialog --version >/dev/null 2>&1') == 0) {
                $this->program('dialog');
                $this->dashsep(''); # dialog does not need (or support) 
                $this->borderwidth(7);
                $this->borderheight(6);
                $this->spacer(0);
                $this->titlespacer(4);
                $this->columnspacer(2);
                $this->selectspacer(0);
                $this->hasoutputfd(1);
        }   
        elsif (Debconf::Path::find("Xdialog") && defined $ENV{DISPLAY}) {
                $this->program("Xdialog");
                $this->borderwidth(7);
                $this->borderheight(20);
                $this->spacer(0);
                $this->titlespacer(10);
                $this->selectspacer(0);
                $this->columnspacer(2);
                $this->screenheight(200);
        }   
        else {
                die gettext("No usable dialog-like program is installed, so the dialog based frontend cannot be used.");
        }
```