### PR TITLE
Don't install empty directories

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,9 +10,5 @@ EXTRA_DIST = \
 	CONTRIBUTING \
 	MAINTAINERS
 
-install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(LXCPATH)
-	$(MKDIR_P) $(DESTDIR)$(localstatedir)/cache/lxc
-
 ChangeLog::
 	@touch ChangeLog


### PR DESCRIPTION
I think this is leftover from when lxc-templates was split out from lxc. There's no need to install empty directories /var/cache/lxc/ and /var/lib/lxc/.