### PR TITLE
Fix alpine template

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -294,7 +294,6 @@ make_dev_nodes() {
 
 	mknod -m 666 dev/tty c 5 0
 	chown 0:5 dev/tty  # root:tty
-	mknod -m 620 dev/console c 5 1
 	mknod -m 666 dev/ptmx c 5 2
 	chown 0:5 dev/ptmx  # root:tty
 }


### PR DESCRIPTION
On a Debian sid system with lxc 5.0.3 and the latest snapshot of lxc-templates, attempting to create an alpine container fails with the error "mknod: dev/console: File exists". This had been reported a while back in Debian bug [#998095](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=998095) and partially addressed in #46.

I performed some testing of the resulting alpine container, and things appear to be working correctly.