### PR TITLE
Update the list of Debian releases that work out of the box

### DIFF
--- a/templates/lxc-debian.in
+++ b/templates/lxc-debian.in
@@ -691,8 +691,8 @@ Options :
   -S, --auth-key=KEYFILE SSH public key to inject into the container as the root user.
   -a, --arch=ARCH        The container architecture. Can be one of: i686, x86_64,
                          amd64, armhf, armel, powerpc. Defaults to host arch.
-  -r, --release=RELEASE  Debian release. Can be one of: wheezy, jessie, stretch, buster,
-                         bullseye, bookworm, trixie, sid. Defaults to current stable.
+  -r, --release=RELEASE  Debian release. Can be one of: buster, bullseye, bookworm, trixie,
+                         testing, sid. Defaults to current stable.
   --mirror=MIRROR        Debian mirror to use during installation. Overrides the MIRROR
                          environment variable (see below).
   --keyring=KEYRING      GPG keyring to authenticate the repository against.


### PR DESCRIPTION
It is still possible to create containers for jessie and stretch, although you need to manually specify the archive mirror and keyring:

    lxc-create -t debian -n stretch -- -r stretch \
      --mirror=http://archive.debian.org/debian \
      --keyring=/usr/share/keyrings/debian-archive-removed-keys.gpg

While the jessie container starts up, it doesn't automatically get an IP -- I didn't perform any further investigation. stretch works just fine.

Debian releases wheezy and earlier fail to create the container in various ways.

This commit just changes the presented list of releases; there is some existing logic for handling archived releases, but I didn't want to risk breaking things by tinkering with the existing code.