### PR TITLE
lxc-alpine: Improve integrity checking of static package manager

### DIFF
--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -222,10 +222,11 @@ fetch_apk_static() {
 	local apk=$dest/sbin/apk.static
 	[ -s "$apk" ] || die 2 'apk.static not found'
 
-	local keyname=$(echo "$apk".*.pub | sed 's/.*\.SIGN\.RSA\.//')
+	local sigprefix=$apk.SIGN.RSA.
+	local keyfile=$(ls -1 "$sigprefix"alpine-*.pub 2>/dev/null | head -n 1)
 	openssl dgst -sha1 \
-		-verify "$APK_KEYS_DIR/$keyname" \
-		-signature "$dest/sbin/apk.static.SIGN.RSA.$keyname" \
+		-verify "$APK_KEYS_DIR/${keyfile#$sigprefix}" \
+		-signature "$keyfile" \
 		"$apk" \
 		|| die 2 'Signature verification for apk.static failed'
 

--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -219,17 +219,18 @@ fetch_apk_static() {
 	fetch "$MIRROR_URL/latest-stable/main/$arch/${pkg_name}-${pkg_ver}.apk" \
 		| tar -xz -C "$dest" sbin/  # --extract --gzip --directory
 
-	[ -s "$dest/sbin/apk.static" ] || die 2 'apk.static not found'
+	local apk=$dest/sbin/apk.static
+	[ -s "$apk" ] || die 2 'apk.static not found'
 
-	local keyname=$(echo "$dest"/sbin/apk.static.*.pub | sed 's/.*\.SIGN\.RSA\.//')
+	local keyname=$(echo "$apk".*.pub | sed 's/.*\.SIGN\.RSA\.//')
 	openssl dgst -sha1 \
 		-verify "$APK_KEYS_DIR/$keyname" \
 		-signature "$dest/sbin/apk.static.SIGN.RSA.$keyname" \
-		"$dest/sbin/apk.static" \
+		"$apk" \
 		|| die 2 'Signature verification for apk.static failed'
 
 	# Note: apk doesn't return 0 for --version
-	local out="$("$dest"/sbin/apk.static --version)"
+	local out=$("$apk" --version)
 	echo "$out"
 
 	[ "${out%% *}" = 'apk-tools' ] || die 3 'apk.static --version failed'

--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -224,11 +224,14 @@ fetch_apk_static() {
 
 	local sigprefix=$apk.SIGN.RSA.
 	local keyfile=$(ls -1 "$sigprefix"alpine-*.pub 2>/dev/null | head -n 1)
-	openssl dgst -sha1 \
+	if ! openssl dgst -sha1 \
 		-verify "$APK_KEYS_DIR/${keyfile#$sigprefix}" \
 		-signature "$keyfile" \
-		"$apk" \
-		|| die 2 'Signature verification for apk.static failed'
+		"$apk"; then
+
+		rm -f "$apk"
+		die 2 'Signature verification for apk.static failed'
+	fi
 
 	# Note: apk doesn't return 0 for --version
 	local out=$("$apk" --version)

--- a/templates/lxc-alpine.in
+++ b/templates/lxc-alpine.in
@@ -203,6 +203,10 @@ fetch_apk_keys() {
 	cd - >/dev/null
 }
 
+find_keyfile() {
+	ls -1 "$1".alpine-*.pub 2>/dev/null | head -n 1
+}
+
 fetch_apk_static() {
 	local dest="$1"
 	local arch="$2"
@@ -222,10 +226,15 @@ fetch_apk_static() {
 	local apk=$dest/sbin/apk.static
 	[ -s "$apk" ] || die 2 'apk.static not found'
 
-	local sigprefix=$apk.SIGN.RSA.
-	local keyfile=$(ls -1 "$sigprefix"alpine-*.pub 2>/dev/null | head -n 1)
-	if ! openssl dgst -sha1 \
-		-verify "$APK_KEYS_DIR/${keyfile#$sigprefix}" \
+	local sigprefix=$apk.SIGN.RSA.sha256
+	local algorithm=sha256
+	if ! [ -s "$(find_keyfile "$sigprefix")" ]; then
+		sigprefix=${sigprefix%.*}
+		algorithm=sha1
+	fi
+	local keyfile=$(find_keyfile "$sigprefix")
+	if ! openssl dgst -$algorithm \
+		-verify "$APK_KEYS_DIR/${keyfile#$sigprefix.}" \
 		-signature "$keyfile" \
 		"$apk"; then
 


### PR DESCRIPTION
This PR improves the integrity checking of the statically linked package manager executable (`apk.static`):
* Do not crash when a SHA256 signature file is present.
* Prefer the SHA256 signature to SHA1 when present.
* Delete the file on verification failure (to prevent it from becoming the default APK executable on the next run).